### PR TITLE
update arm-none-eabi-gcc version

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -3,7 +3,7 @@ require 'formula'
 class ArmNoneEabiGcc < Formula
 
   homepage 'https://launchpad.net/gcc-arm-embdded'
-  version '20130313'
+  version '20130916'
   url 'https://launchpadlibrarian.net/151487551/gcc-arm-none-eabi-4_7-2013q3-20130916-mac.tar.bz2'
   sha1 'a29eda3d4351bfe47749a242f6faa7cbd630d28b'
 


### PR DESCRIPTION
The version of package arm-none-eabi-gcc is not matched the name of downloaded file, so keep it updated. 
