### PR TITLE
Add depends_on autoconf

### DIFF
--- a/stlink.rb
+++ b/stlink.rb
@@ -6,6 +6,7 @@ class Stlink < Formula
     head 'https://github.com/texane/stlink.git'
 
     depends_on 'automake' => :build
+    depends_on 'autoconf' => :build
     depends_on 'libusb' => :build
     depends_on 'pkg-config' => :build
 


### PR DESCRIPTION
Fix error:
"./autogen.sh: line 2: autoreconf: command not found"
