### PR TITLE
arm-none-eabi-gcc: updated version to 20140314 release.

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -3,10 +3,10 @@ require 'formula'
 class ArmNoneEabiGcc < Formula
 
   homepage 'https://launchpad.net/gcc-arm-embdded'
-  version '20130916'
-  url 'https://launchpadlibrarian.net/151487551/gcc-arm-none-eabi-4_7-2013q3-20130916-mac.tar.bz2'
-  sha1 'a29eda3d4351bfe47749a242f6faa7cbd630d28b'
-
+  version '20140314'
+  url 'https://launchpadlibrarian.net/170926386/gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2'
+  sha1 'b40c4127f641170f016b77ad423caf8dfd46faac'
+  
   def install
     system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
   end


### PR DESCRIPTION
I use a number of C++11 features in G++ 4.8, so I thought I'd throw in an update here.
