### PR TITLE
arm-none-eabi-gcc 20140609

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -3,9 +3,9 @@ require 'formula'
 class ArmNoneEabiGcc < Formula
 
   homepage 'https://launchpad.net/gcc-arm-embedded'
-  version '20140314'
-  url 'https://launchpadlibrarian.net/170926386/gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2'
-  sha1 'b40c4127f641170f016b77ad423caf8dfd46faac'
+  version '20140609'
+  url 'https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q2-update/+download/gcc-arm-none-eabi-4_8-2014q2-20140609-mac.tar.bz2'
+  sha1 '751895b7c967dcc964b98c86f06198a3457a859e'
   
   def install
     system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"


### PR DESCRIPTION
Updates ARM GCC Toolchain to latest version 20140609 (and fixes launchpad URL)
